### PR TITLE
Update https-proxy-agent dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-digitaloak-mqtt",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "node-red": {
     "nodes": {
       "digitaloak-mqtt-in": "mqtt.js"
@@ -11,7 +11,7 @@
     "is-utf8": "^0.2.1",
     "util": "^0.12.1",
     "url": "^0.11.0",
-    "https-proxy-agent": "^2.2.2"
+    "https-proxy-agent": "^3.0.0"
   },
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
Update https-proxy-agent to 3.0.0, fixes security issue.