### PR TITLE
Remove usage of https-proxy-agent

### DIFF
--- a/mqtt.js
+++ b/mqtt.js
@@ -18,7 +18,6 @@ module.exports = function (RED) {
     var mqtt = require("mqtt");
     var util = require("util");
     var isUtf8 = require('is-utf8');
-    var HttpsProxyAgent = require('https-proxy-agent');
     var url = require('url');
 
     function digitaloak_MQTTInNode(n) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-digitaloak-mqtt",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "node-red": {
     "nodes": {
       "digitaloak-mqtt-in": "mqtt.js"
@@ -10,8 +10,7 @@
     "mqtt": "^3.0.0",
     "is-utf8": "^0.2.1",
     "util": "^0.12.1",
-    "url": "^0.11.0",
-    "https-proxy-agent": "^3.0.0"
+    "url": "^0.11.0"
   },
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
Remove usage of unused https-proxy-agent on the code.

Please note that this dependency cause issues with Node Red 3.1 and later.

